### PR TITLE
Improved Copy-ProjectResource function to copy only folder contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The `resources` folder within the `src` directory is intended for including any 
 
 When the module is built, the contents of the `src/resources` folder will be copied directly to the `dist` folder. If the `src/resources` folder contains any subfolders, those subfolders and their contents will also be included in the `dist` folder, ensuring that all necessary files are available for the module to function correctly.
 
-How the resources folder gets copied to the "OutputModuleDir" folder will depends on the "CopyMode" project setting. When missing or set to "Folder", the resources folder will be copied. When "CopyMode" is set to "Content", then only the content of the resources folder will be copied.
+How the resources folder gets copied to the "OutputModuleDir" folder will depends on the "ResourceCopyMode" project setting. When missing or set to "Folder", the resources folder will be copied. When "ResourceCopyMode" is set to "Content", then only the content of the resources folder will be copied.
 
 Leave `src\resources` empty if there is no need to include any additional content in the `dist` folder.
 
@@ -127,10 +127,10 @@ New-MTModule ~/Work
 
 `ModuleTools` is designed so that you don't need any additional tools like `make` or `psake` to run the build commands. There's no need to maintain complex `build.ps1` files or sample `.psd1` files. Simply follow the structure outlined above, and you can run `Invoke-MTBuild` to build the module. The output will be saved in the `dist` folder, ready for distribution.
 
-The Invoke-MTBuild CmdLet includes a step where the resources folder and/or it's contents are copied to the "OutputModuleDir" folder. This is controlled by the optional "CopyMode" project setting.
+The Invoke-MTBuild CmdLet includes a step where the resources folder and/or it's contents are copied to the "OutputModuleDir" folder. This is controlled by the optional "ResourceCopyMode" project setting.
 
-If "CopyMode" = 'Folder or if it's missing, the entire resources folder gets copied to the "OutputModuleDir" folder.
-If "CopyMode" = 'Content', only the content of the resources folder gets copied to the "OutputModuleDir" folder.
+If "ResourceCopyMode" = 'Folder or if it's missing, the entire resources folder gets copied to the "OutputModuleDir" folder.
+If "ResourceCopyMode" = 'Content', only the content of the resources folder gets copied to the "OutputModuleDir" folder.
 
 ```powershell
 # From the Module root 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ Generated module is stored in dist folder, you can easily import it or publish i
    └──  TestModule.psm1
 ```
 
-
-
 ### Project JSON File
 
 The `project.json` file contains all the important details about your module and is used during the module build. It should comply with a specific schema. You can refer to the sample `project-sample.json` file in the `example` directory for guidance.
@@ -75,6 +73,38 @@ Run `New-MTModule` to generate the scaffolding; this will also create the `proje
   - Place all your functions in the `private` and `public` folders within the `src` directory.
   - All functions in the `public` folder are exported during the module build.
   - All functions in the `private` folder are accessible internally within the module but are not exposed outside the module.
+  - Contents of the `src/resources` folder, including any subfolder, will included in the `dist` folder during the module build.
+
+#### resources Folder
+
+The `resources` folder within the `src` directory is intended for including any additional resources required by your module. This can include files such as:
+
+- **Configuration files**: Store any JSON, XML, or other configuration files needed by your module.
+- **Script files**: Place any scripts that are used by your functions or modules, but are not directly part of the public or private functions.
+- **Documentation files**: Include any supplementary documentation that supports the usage or development of the module.
+- **Data files**: Store any data files that are used by your module, such as CSV or JSON files.
+- **Subfolder**: Include any additional folders and their content to be included with the module, such as dependant Modules, APIs, DLLs, etc... organized by a subfolder.
+
+When the module is built, the contents of the `src/resources` folder will be copied directly to the `dist` folder. If the `src/resources` folder contains any subfolders, those subfolders and their contents will also be included in the `dist` folder, ensuring that all necessary files are available for the module to function correctly.
+
+Leave `src\resources` empty if there is no need to include any additional content in the `dist` folder.
+
+An example of the module build where resources were included:
+
+```
+dist
+└── TestModule
+        ├── TestModule.psd1
+        ├── TestModule.psm1
+        ├── config.json
+        ├── additionalScript.ps1
+        ├── helpDocumentation.md
+        ├── sampleData.csv
+        └── subfolder
+            ├── subConfig.json
+            ├── subScript.ps1
+            └── subData.csv
+```
 
 ### Tests Folder
 
@@ -126,7 +156,15 @@ A simple command to update the module version by modifying the values in `projec
 
 ## Advanced - Use it in Github Actions
 
-This is not required for local module builds, if you are running github actions, use below template to test, build and publish module with ease.
+This is not required for local module builds, if you are running github actions, use the following yaml workflow template to test, build and publish module which helps to automate the process of:
+
+1. Checking out the repository code.
+1. Installing the `ModuleTools` module from the PowerShell Gallery.
+1. Building the module.
+1. Running Pester tests.
+1. Publishing the module to a specified repository.
+
+This allows for seamless and automated management of your PowerShell module, ensuring consistency and reliability in your build, test, and release processes.
 
 ```yaml
 name: Build, Test and Publish
@@ -154,6 +192,7 @@ jobs:
       - name: Run Pester Tests
         run: Invoke-MTTest
         shell: pwsh
+
       - name: Publish Package to Github
         run: |
           Publish-PSResource -Path ./dist/YourModule -Repository SomeRepository -ApiKey $Env:ApiKey

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Whether you're creating simple or robust modules, ModuleTools streamlines the pr
 [![ModuleTools@PowerShell Gallery][BadgeIOCount]][PSGalleryLink]
 ![WorkFlow Status][WorkFlowStatus]
 
-
-
 The structure of the ModuleTools module is meticulously designed according to PowerShell best practices for module development. While some design decisions may seem unconventional, they are made to ensure that ModuleTools and the process of building modules remain straightforward and easy to manage.
 
 > [!IMPORTANT]
@@ -28,7 +26,7 @@ The structure of the ModuleTools module is meticulously designed according to Po
 Install-Module -Name ModuleTools
 ```
 
-> Note: ModuleTolls is still in early devleopment phase and lot of changes are expected. Please read through [ChangeLog](/CHANGELOG.md) for all updates.
+> Note: ModuleTolls is still in early development phase and lot of changes are expected. Please read through [ChangeLog](/CHANGELOG.md) for all updates.
 
 ## 🧵 Design
 
@@ -70,10 +68,10 @@ Run `New-MTModule` to generate the scaffolding; this will also create the `proje
 
 ### Src Folder
 
-  - Place all your functions in the `private` and `public` folders within the `src` directory.
-  - All functions in the `public` folder are exported during the module build.
-  - All functions in the `private` folder are accessible internally within the module but are not exposed outside the module.
-  - Contents of the `src/resources` folder, including any subfolder, will included in the `dist` folder during the module build.
+- Place all your functions in the `private` and `public` folders within the `src` directory.
+- All functions in the `public` folder are exported during the module build.
+- All functions in the `private` folder are accessible internally within the module but are not exposed outside the module.
+- Contents of the `src/resources` folder, including any subfolder, will included in the `dist` folder during the module build.
 
 #### resources Folder
 
@@ -87,11 +85,13 @@ The `resources` folder within the `src` directory is intended for including any 
 
 When the module is built, the contents of the `src/resources` folder will be copied directly to the `dist` folder. If the `src/resources` folder contains any subfolders, those subfolders and their contents will also be included in the `dist` folder, ensuring that all necessary files are available for the module to function correctly.
 
+How the resources folder gets copied to the "OutputModuleDir" folder will depends on the "CopyMode" project setting. When missing or set to "Folder", the resources folder will be copied. When "CopyMode" is set to "Content", then only the content of the resources folder will be copied.
+
 Leave `src\resources` empty if there is no need to include any additional content in the `dist` folder.
 
 An example of the module build where resources were included:
 
-```
+```powershell
 dist
 └── TestModule
         ├── TestModule.psd1
@@ -126,6 +126,11 @@ New-MTModule ~/Work
 ### Invoke-MTBuild
 
 `ModuleTools` is designed so that you don't need any additional tools like `make` or `psake` to run the build commands. There's no need to maintain complex `build.ps1` files or sample `.psd1` files. Simply follow the structure outlined above, and you can run `Invoke-MTBuild` to build the module. The output will be saved in the `dist` folder, ready for distribution.
+
+The Invoke-MTBuild CmdLet includes a step where the resources folder and/or it's contents are copied to the "OutputModuleDir" folder. This is controlled by the optional "CopyMode" project setting.
+
+If "CopyMode" = 'Folder or if it's missing, the entire resources folder gets copied to the "OutputModuleDir" folder.
+If "CopyMode" = 'Content', only the content of the resources folder gets copied to the "OutputModuleDir" folder.
 
 ```powershell
 # From the Module root 

--- a/project.json
+++ b/project.json
@@ -2,7 +2,7 @@
   "ProjectName": "ModuleTools",
   "Description": "ModuleTools is a versatile, standalone PowerShell module builder. Create anything from simple to robust modules with ease. Built for CICD and Automation.",
   "Version": "0.0.10",
-  "CopyMode": "Folder",
+  "ResourceCopyMode": "Folder",
   "Manifest": {
     "Author": "Manjunath Beli",
     "PowerShellHostVersion": "7.4",

--- a/project.json
+++ b/project.json
@@ -2,6 +2,7 @@
   "ProjectName": "ModuleTools",
   "Description": "ModuleTools is a versatile, standalone PowerShell module builder. Create anything from simple to robust modules with ease. Built for CICD and Automation.",
   "Version": "0.0.10",
+  "CopyMode": "Folder",
   "Manifest": {
     "Author": "Manjunath Beli",
     "PowerShellHostVersion": "7.4",

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "ModuleTools",
   "Description": "ModuleTools is a versatile, standalone PowerShell module builder. Create anything from simple to robust modules with ease. Built for CICD and Automation.",
-  "Version": "0.0.9",
+  "Version": "0.0.10",
   "Manifest": {
     "Author": "Manjunath Beli",
     "PowerShellHostVersion": "7.4",

--- a/src/private/CopyProjectResource.ps1
+++ b/src/private/CopyProjectResource.ps1
@@ -3,9 +3,12 @@ function Copy-ProjectResource {
     $resFolder = [System.IO.Path]::Join($data.ProjectRoot, 'src', 'resources')
 
     if (Test-Path $resFolder) {
-        if (Get-ChildItem $resFolder -ErrorAction SilentlyContinue) {
-            Write-Verbose 'Files found in resource folder, Copying resource folder content'
-            Copy-Item -Path $resFolder -Destination ($data.OutputModuleDir) -Recurse -Force -ErrorAction Stop
+        $items = Get-ChildItem -Path $resFolder -ErrorAction SilentlyContinue
+        if ($items) {
+            Write-Verbose 'Files found in resource folder, copying resource folder content'
+            foreach ($item in $items) {
+                Copy-Item -Path $item.FullName -Destination ($data.OutputModuleDir) -Recurse -Force -ErrorAction Stop
+            }
         }
     }
 }

--- a/src/private/CopyProjectResource.ps1
+++ b/src/private/CopyProjectResource.ps1
@@ -2,7 +2,7 @@ function Copy-ProjectResource {
     $data = Get-MTProjectInfo
     $resFolder = [System.IO.Path]::Join($data.ProjectRoot, 'src', 'resources')
     if (Test-Path $resFolder) {
-        if ($data.CopyMode -eq 'Content') {
+        if ($data.ResourceCopyMode -eq 'Content') {
             # Copy the resources folder content to the OutputModuleDir
             $items = Get-ChildItem -Path $resFolder -ErrorAction SilentlyContinue
             if ($items) {

--- a/src/private/CopyProjectResource.ps1
+++ b/src/private/CopyProjectResource.ps1
@@ -1,13 +1,21 @@
 function Copy-ProjectResource {
     $data = Get-MTProjectInfo
     $resFolder = [System.IO.Path]::Join($data.ProjectRoot, 'src', 'resources')
-
     if (Test-Path $resFolder) {
-        $items = Get-ChildItem -Path $resFolder -ErrorAction SilentlyContinue
-        if ($items) {
-            Write-Verbose 'Files found in resource folder, copying resource folder content'
-            foreach ($item in $items) {
-                Copy-Item -Path $item.FullName -Destination ($data.OutputModuleDir) -Recurse -Force -ErrorAction Stop
+        if ($data.CopyMode -eq 'Content') {
+            # Copy the resources folder content to the OutputModuleDir
+            $items = Get-ChildItem -Path $resFolder -ErrorAction SilentlyContinue
+            if ($items) {
+                Write-Verbose 'Files found in resource folder, copying resource folder content'
+                foreach ($item in $items) {
+                    Copy-Item -Path $item.FullName -Destination ($data.OutputModuleDir) -Recurse -Force -ErrorAction Stop
+                }
+            }
+        } else {
+            # Copy the resources folder to the OutputModuleDir
+            if (Get-ChildItem $resFolder -ErrorAction SilentlyContinue) {
+                Write-Verbose 'Files found in resource folder, Copying resource folder'
+                Copy-Item -Path $resFolder -Destination ($data.OutputModuleDir) -Recurse -Force -ErrorAction Stop
             }
         }
     }

--- a/src/resources/ProjectTemplate.json
+++ b/src/resources/ProjectTemplate.json
@@ -2,6 +2,7 @@
     "ProjectName": "",
     "Description": "",
     "Version": "",
+    "CopyMode": "",
     "Manifest": {
         "Author": "",
         "PowerShellHostVersion": "",

--- a/src/resources/ProjectTemplate.json
+++ b/src/resources/ProjectTemplate.json
@@ -2,7 +2,7 @@
     "ProjectName": "",
     "Description": "",
     "Version": "",
-    "CopyMode": "",
+    "ResourceCopyMode": "",
     "Manifest": {
         "Author": "",
         "PowerShellHostVersion": "",

--- a/src/resources/Schema-Build.json
+++ b/src/resources/Schema-Build.json
@@ -12,7 +12,7 @@
         "Version": {
             "type": "string"
         },
-        "CopyMode": {
+        "ResourceCopyMode": {
             "type": "string"
         },        
         "Manifest": {

--- a/src/resources/Schema-Build.json
+++ b/src/resources/Schema-Build.json
@@ -12,6 +12,9 @@
         "Version": {
             "type": "string"
         },
+        "CopyMode": {
+            "type": "string"
+        },        
         "Manifest": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
Updated ./src/private/CopyProjectResource.ps1 by recursively copying the contents of the ./src/resources folder to the ./dist/<moduleName> folder instead of copying the ./src/resources folder with it's contents.
