### PR TITLE
Get-aliases-from-file

### DIFF
--- a/src/private/Build.Manifest.ps1
+++ b/src/private/Build.Manifest.ps1
@@ -6,8 +6,10 @@ function Build-Manifest {
 
     $PubFunctionFiles = Get-ChildItem -Path $data.PublicDir -Filter *.ps1
     $functionToExport = @()
+    $aliasesToExport = @()
     $PubFunctionFiles | ForEach-Object {
         $functionToExport += Get-FunctionNameFromFile -filePath $_.FullName
+        $aliasesToExport += Get-AliasNamesFromFile -filePath $_.FullName
     }
 
     $ManfiestAllowedParams = (Get-Command New-ModuleManifest).Parameters.Keys
@@ -16,6 +18,7 @@ function Build-Manifest {
         Path              = $data.ManifestFilePSD1
         Description       = $data.Description
         FunctionsToExport = $functionToExport
+        AliasesToExport   = $aliasesToExport
         RootModule        = "$($data.ProjectName).psm1"
         ModuleVersion     = $data.Version
     }

--- a/src/private/GetAliasNamesFromFile.ps1
+++ b/src/private/GetAliasNamesFromFile.ps1
@@ -1,0 +1,54 @@
+# Get-AliasNamesFromFile
+function Get-AliasNamesFromFile {
+    param($filePath)
+
+    $aliasToExport = @()
+
+    try {
+        $moduleContent = Get-Content -Path $filePath -Raw
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput($moduleContent, [ref]$null, [ref]$null)
+
+        # Find and add aliases defined by Set-Alias
+        $ast.EndBlock.Statements
+        | Where-Object { $_ -match "^\s*Set-Alias .+" }
+        | ForEach-Object { $_.Extent.text }
+        | ForEach-Object {
+            $params = $_ -split '\s+'
+            # $content += "`n$_"
+
+            if ($_ -imatch "-na") {
+                # alias is defined using -Name parameter to Set-Alias
+                # so get the alias name from the next parameter
+                $i = 0
+                $parNameLoc = 0
+                ForEach ($par in $params) {
+                    if ($par -imatch "-na") {
+                        $parNameLoc = $i
+                    }
+                    ++$i
+                }
+                $aliasToExport += $params[$parNameLoc + 1]
+            }
+            else {
+                $aliasToExport += $params[1]
+            }
+            # Write-Verbose "Content: $_"
+        }
+
+        # Find and add aliases defined by [Alias("Some-Alias")] attribute
+        $insideFunctionAliasName = $ast.FindAll({
+            $args[0] -is [System.Management.Automation.Language.AttributeAst]
+        }, $true)
+        | Where-Object { $_.Parent.Extent.text -match '^param' }
+        | Select-Object -ExpandProperty PositionalArguments
+        | Select-Object -ExpandProperty Value -ErrorAction SilentlyContinue
+
+        if ($insideFunctionAliasName) {
+            $insideFunctionAliasName | ForEach-Object {
+                $aliasToExport += $_
+            }
+        }
+        return $aliasToExport
+    }
+    catch { return '' }
+}

--- a/src/private/GetFunctionNameFromFile.ps1
+++ b/src/private/GetFunctionNameFromFile.ps1
@@ -3,7 +3,13 @@ function Get-FunctionNameFromFile {
     try {
         $moduleContent = Get-Content -Path $filePath -Raw
         $ast = [System.Management.Automation.Language.Parser]::ParseInput($moduleContent, [ref]$null, [ref]$null)
-        $functionName = $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $false) | ForEach-Object { $_.Name } 
+        $functionName = $ast.FindAll({
+            $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            # Ignore Functions defined inside other Functions (e.g., nested functions or Class methods)
+            ($PSVersionTable.PSVersion.Major -lt 5 -or
+            $args[0].Parent -isnot [System.Management.Automation.Language.FunctionMemberAst])
+        }, $false) | ForEach-Object { $_.Name }
+
         return $functionName
     }
     catch { return '' }


### PR DESCRIPTION
Added functionality to handle parsing the public/*.ps1 files for [Alias("aliasname")] in the function or Set-Alias commands outside the functions. Modified Build-Module to use this alias list to add the Export-ModuleMember command to the end of the PSM1. Modified Build-Manifest to add the AliasesToExport to the Manifest file. 

I have tested this with a local Module I'm working on, and it seems to be working as expected. Not sure if you'll be able to incorporate this into your repo, but thought I'd do the PR so you can decide if you want to use it. 